### PR TITLE
Make material status case insensitive

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -185,8 +185,8 @@
           <div id="events" class="tab-pane fade in active">
             <div class="row">
               <div class="search-results-count">
-                <%= (upcoming_events.count > 0 ? "Showing" : "Found") + events.count.to_s + " #{"upcoming event".pluralize(events.count)}#{(upcoming_events.count > resource_limit) ? " out of #{upcoming_events.count}" : ''}." %>
-                <%= "Found “ + past_events.count.to_s + #{"past event".pluralize(past_events.count)}." %>
+                <%= (upcoming_events.count > 0 ? "Showing" : "Found") + " " + events.count.to_s + " #{"upcoming event".pluralize(events.count)}#{(upcoming_events.count > resource_limit) ? " out of #{upcoming_events.count}" : ''}." %>
+                <%= "Found " + past_events.count.to_s + " #{"past event".pluralize(past_events.count)}." %>
               </div>
               <ul>
                 <% if upcoming_events.count > resource_limit %>
@@ -212,7 +212,7 @@
           <div id="materials" class="tab-pane fade">
             <div class="row">
               <div class="search-results-count">
-                <%= (materials.count > 0 ? "Showing" : "Found") + " #{pluralize(materials.count, "material")}#{(@user.materials.count > resource_limit) ? " out of #{@user.materials.count}" : ''}." %>
+                <%= (materials.count > 0 ? "Showing" : "Found") + " " + materials.count.to_s + " #{"material".pluralize(materials.count)}#{(@user.materials.count > resource_limit) ? " out of #{@user.materials.count}" : ''}." %>
                 <%= link_to('View all results.', materials_path(user: @user.username)) if (@user.materials.count > resource_limit) %>
               </div>
               <% materials.each do |material| %>

--- a/lib/ingestors/ingestor_event_csv.rb
+++ b/lib/ingestors/ingestor_event_csv.rb
@@ -14,7 +14,7 @@ class IngestorEventCsv < IngestorEvent
       # parse csv as table
       web_contents = open(url).read
       table = CSV.parse web_contents, headers: true
-
+   
       # process each row
       table.each do |row|
         # copy values

--- a/lib/ingestors/ingestor_material_csv.rb
+++ b/lib/ingestors/ingestor_material_csv.rb
@@ -25,6 +25,8 @@ class IngestorMaterialCsv < IngestorMaterial
         material.contact = get_column row, 'Contact'
         material.licence = get_column row, 'Licence'
         material.status = get_column row, 'Status'
+        material.status = material.status.downcase
+
 
         # copy optional values
         material.doi = get_column row, 'DOI'


### PR DESCRIPTION
Dresa auto-ingestion could only detect "active" but not "Active" for status.  This update will make it case-insensitive.